### PR TITLE
Update OpenAI API endpoints to use production URLs and enhance Wareho…

### DIFF
--- a/MrBean/src/main/java/com/mrbean/warehouse/WarehouseDTO.java
+++ b/MrBean/src/main/java/com/mrbean/warehouse/WarehouseDTO.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
@@ -16,6 +17,7 @@ public class WarehouseDTO {
     @JsonProperty("wCode")
     @NotBlank(message = "창고 코드는 필수 입력 사항입니다.\n")
     @Size(max = 10, message = "창고 코드는 10자를 넘을 수 없습니다.")
+    @Pattern(regexp = "^[A-Z]{1}[1-9]{1}[0-9]{0,1}$", message = "창고 코드는 A1~Z99 형식이어야 합니다.")
     private String wCode;
 
     @JsonProperty("wName")

--- a/MrBean/src/main/webapp/resources/js/chatbot/openai.js
+++ b/MrBean/src/main/webapp/resources/js/chatbot/openai.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
 
     async function loadChatHistory() {
         try {
-            const response = await fetch('http://localhost:8000/chatbot/history');
+            const response = await fetch('https://app.c7d2408t2p2.itwillbs.com/chatbot/history');
             const data = await response.json();
             if (data.messages && Array.isArray(data.messages)) {
                 data.messages.forEach(msg => {
@@ -32,7 +32,7 @@ $(document).ready(function() {
 
     async function saveChatMessage(message, isUser) {
         try {
-            const response = await fetch('http://localhost:8000/chatbot/save', {
+            const response = await fetch('https://app.c7d2408t2p2.itwillbs.com/chatbot/save', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -63,7 +63,7 @@ async function sendMessage() {
     let botResponse = '';
 
     try {
-        const response = await fetch('http://localhost:8000/chatbot/', {
+        const response = await fetch('https://app.c7d2408t2p2.itwillbs.com/chatbot', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ query: message })


### PR DESCRIPTION
This pull request includes changes to add validation to the `WarehouseDTO` class and update the URLs in the chatbot JavaScript file to use the production server.

Validation improvements:

* [`MrBean/src/main/java/com/mrbean/warehouse/WarehouseDTO.java`](diffhunk://#diff-c3c5efd8f633c686a4a19d1f1a8bf89289a3cf586794b3682e0bbf5015517141R20): Added `@Pattern` annotation to `wCode` to enforce the format "A1~Z99".

URL updates for production:

* [`MrBean/src/main/webapp/resources/js/chatbot/openai.js`](diffhunk://#diff-32313af28e0a904a5a2aca2cca3636becf34dfef4dd2982bfa1f65db2653353fL21-R21): Updated the URLs for fetching chat history, saving chat messages, and sending messages to use the production server `https://app.c7d2408t2p2.itwillbs.com` instead of `http://localhost:8000`. [[1]](diffhunk://#diff-32313af28e0a904a5a2aca2cca3636becf34dfef4dd2982bfa1f65db2653353fL21-R21) [[2]](diffhunk://#diff-32313af28e0a904a5a2aca2cca3636becf34dfef4dd2982bfa1f65db2653353fL35-R35) [[3]](diffhunk://#diff-32313af28e0a904a5a2aca2cca3636becf34dfef4dd2982bfa1f65db2653353fL66-R66)